### PR TITLE
Fix display bug: account for possible empty notes array

### DIFF
--- a/src/scripts/loadSubset.js
+++ b/src/scripts/loadSubset.js
@@ -46,7 +46,6 @@ function getLanguageText(multilingualTextArray, languageCode) {
 }
 
 function getLanguageTextOrDefault(multilingualTextArray, languageCode, defaultLanguageCode){
-    console.log("getLanguageTextOrDefault(), mlta: "+JSON.stringify(multilingualTextArray))
     let text = getLanguageText(multilingualTextArray, languageCode);
     if (text === "")
         text = getLanguageText(multilingualTextArray, defaultLanguageCode);

--- a/src/scripts/loadSubset.js
+++ b/src/scripts/loadSubset.js
@@ -46,10 +46,11 @@ function getLanguageText(multilingualTextArray, languageCode) {
 }
 
 function getLanguageTextOrDefault(multilingualTextArray, languageCode, defaultLanguageCode){
+    console.log("getLanguageTextOrDefault(), mlta: "+JSON.stringify(multilingualTextArray))
     let text = getLanguageText(multilingualTextArray, languageCode);
     if (text === "")
         text = getLanguageText(multilingualTextArray, defaultLanguageCode);
-    if (text === "")
+    if (text === "" && multilingualTextArray.size > 0)
         text = multilingualTextArray[0]["languageText"];
     return text;
 }


### PR DESCRIPTION
A bug happened where a subse would not display properly. This occurred when the "notes" array of a subset code was completely empty, rather than containing empty notes. I now account for this possibility, and the subset displays correctly.